### PR TITLE
Fix missing __dso_handle in Emacs 24.3

### DIFF
--- a/all-dso-handle.patch
+++ b/all-dso-handle.patch
@@ -1,0 +1,13 @@
+https://bugs.gentoo.org/682282
+
+--- emacs-23.4-orig/src/emacs.c
++++ emacs-23.4/src/emacs.c
+@@ -217,6 +217,8 @@
+    output a warning in dump-emacs.  */
+ #define MAX_HEAP_BSS_DIFF (1024*1024)
+ 
++void *__dso_handle = NULL;
++
+ 
+ #ifdef HAVE_WINDOW_SYSTEM
+ extern Lisp_Object Vinitial_window_system;

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,4 @@
 let
-  nixpkgs-1709 = import (builtins.fetchTarball {
-    url = https://github.com/NixOS/nixpkgs/archive/14f9ee66e63077539252f8b4550049381a082518.tar.gz;
-    sha256 = "1wn7nmb1cqfk2j91l3rwc6yhimfkzxprb8wknw5wi57yhq9m6lv1";
-  }) {};
-
   nixpkgs-1903 = import (builtins.fetchTarball {
     url = https://github.com/NixOS/nixpkgs/archive/aa34ca05fe5b0bc2cc36d67aed023110da226164.tar.gz;
     sha256 = "1lsywp26kq426bmywxq2d1n8s39p3cy4y93xplkgqbi5qj6xgl6z";
@@ -11,19 +6,18 @@ let
 
   pkgs = nixpkgs-1903;
 
-  old-emacs-pkgs = if pkgs.stdenv.isLinux then nixpkgs-1709 else pkgs;
-
 in
 {
   # TODO: These early versions fail for me at the bootstrap phase on MacOS
   #emacs-24-1 = old-emacs-pkgs.callPackage ./emacs.nix { version = "24.1"; sha256 = "1awbgkwinpqpzcn841kaw5cszdn8sx6jyfp879a5bff0v78nvlk0"; };
   #emacs-24-2 = old-emacs-pkgs.callPackage ./emacs.nix { version = "24.2"; sha256 = "0mykbg5rzrm2h4805y4nl5vpvwx4xcmp285sbr51sxp1yvgr563d"; withAutoReconf = false; };
 
-  emacs-24-3 = with old-emacs-pkgs; callPackage ./emacs.nix {
+  emacs-24-3 = with pkgs; callPackage ./emacs.nix {
     version = "24.3";
     sha256 = "0hggksbn9h5gxmmzbgzlc8hgl0c77simn10jhk6njgc10hrcm600";
     withAutoReconf = false;
     stdenv = clangStdenv;
+    patches = [ ./all-dso-handle.patch ];
   };
 
   emacs-24-4 = with pkgs; callPackage ./emacs.nix {

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ in
     version = "24.3";
     sha256 = "0hggksbn9h5gxmmzbgzlc8hgl0c77simn10jhk6njgc10hrcm600";
     withAutoReconf = false;
-    stdenv = clangStdenv;
+    stdenv = if stdenv.cc.isGNU then overrideCC stdenv gcc49 else stdenv;
     patches = [ ./all-dso-handle.patch ];
   };
 
@@ -24,14 +24,14 @@ in
     version = "24.4";
     sha256 = "1iicqcijr56r7vxxm3v3qhf69xpxlpq7afbjr6h6bpjsz8d4yg59";
     withAutoReconf = false;
-    stdenv = clangStdenv;
+    stdenv = if stdenv.cc.isGNU then overrideCC stdenv gcc49 else stdenv;
   };
 
   emacs-24-5 = with pkgs; callPackage ./emacs.nix {
     version = "24.5";
     sha256 = "1dn3jx1dph5wr47v97g0fhka9gcpn8pnzys7khp9indj5xiacdr7";
     withAutoReconf = false;
-    stdenv = clangStdenv;
+    stdenv = if stdenv.cc.isGNU then overrideCC stdenv gcc49 else stdenv;
   };
 
   emacs-25-1 = pkgs.callPackage ./emacs.nix { version = "25.1"; sha256 = "0rqw9ama0j5b6l4czqj4wlf21gcxi9s18p8cx6ghxm5l1nwl8cvn"; withAutoReconf = true; };

--- a/emacs.nix
+++ b/emacs.nix
@@ -3,6 +3,7 @@
 , stdenv, lib, fetchurl, ncurses, autoreconfHook
 , pkgconfig, libxml2, gettext, gnutls
 , withAutoReconf ? false
+, patches ? []
 }:
 
 # A very minimal version of https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/emacs/default.nix
@@ -25,6 +26,8 @@ stdenv.mkDerivation rec {
     [ ncurses libxml2 gnutls gettext ];
 
   hardeningDisable = [ "format" ];
+
+  inherit patches;
 
   configureFlags = [
     "--disable-build-details" # for a (more) reproducible build


### PR DESCRIPTION
Emacs 24.3 needs some patches to work with newer binutils / glibc / gcc combinations. This fix is taken from https://bugs.gentoo.org/682282.

Note that older Nixpkgs channels do work as well, and most likely more of these patches will be necessary in the future as more breaking changes happen. nixos-14.04 can also be used to get Emacs 24.3:

```
nix build -f channel:nixos-14.04 pkgs.emacs
```