### PR TITLE
Add the version to each derivation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,4 @@ jobs:
         name: emacs-ci
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: nix-build -A emacs-${{ matrix.attr }}
+    - run: nix-build --argstr emacsAttr emacs-${{ matrix.attr }} tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,4 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: nix-build -A emacs-${{ matrix.attr }}
     - run: nix-build --argstr emacsAttr emacs-${{ matrix.attr }} tests
+      if: ${{ ! contains( fromJson('[ "23-4", "24-1", "24-2", "24-3" ]'), matrix.attr ) }}

--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,7 @@ let
   pkgs = import sources.nixpkgs {};
 
   release = version: sha256: rec {
+    inherit version;
     name = "emacs-${version}";
     src = pkgs.fetchurl {
       inherit sha256;
@@ -31,7 +32,7 @@ in
   if pkgs.stdenv.isLinux then {
 
     emacs-23-4 = with pkgs; callPackage ./emacs.nix {
-      inherit (release "23.4" "1fc8x5p38qihg7l6z2b1hjc534lnjb8gqpwgywlwg5s3csg6ymr6") name src;
+      inherit (release "23.4" "1fc8x5p38qihg7l6z2b1hjc534lnjb8gqpwgywlwg5s3csg6ymr6") name src version;
       withAutoReconf = false;
       stdenv = if stdenv.cc.isGNU then gcc49Stdenv else stdenv;
       patches = [
@@ -42,7 +43,7 @@ in
     };
 
     emacs-24-1 = with pkgs; callPackage ./emacs.nix {
-      inherit (release "24.1" "1awbgkwinpqpzcn841kaw5cszdn8sx6jyfp879a5bff0v78nvlk0") name src;
+      inherit (release "24.1" "1awbgkwinpqpzcn841kaw5cszdn8sx6jyfp879a5bff0v78nvlk0") name src version;
       withAutoReconf = false;
       stdenv = if stdenv.cc.isGNU then gcc49Stdenv else stdenv;
       patches = [
@@ -53,7 +54,7 @@ in
     };
 
     emacs-24-2 = with pkgs; callPackage ./emacs.nix {
-      inherit (release "24.2" "0mykbg5rzrm2h4805y4nl5vpvwx4xcmp285sbr51sxp1yvgr563d") name src;
+      inherit (release "24.2" "0mykbg5rzrm2h4805y4nl5vpvwx4xcmp285sbr51sxp1yvgr563d") name src version;
       withAutoReconf = false;
       stdenv = if stdenv.cc.isGNU then gcc49Stdenv else stdenv;
       patches = [ ./patches/all-dso-handle.patch ./patches/fpending-24.1.patch ];
@@ -61,28 +62,28 @@ in
   } else {}
 ) // {
   emacs-24-3 = with pkgs; callPackage ./emacs.nix {
-    inherit (release "24.3" "0hggksbn9h5gxmmzbgzlc8hgl0c77simn10jhk6njgc10hrcm600") name src;
+    inherit (release "24.3" "0hggksbn9h5gxmmzbgzlc8hgl0c77simn10jhk6njgc10hrcm600") name src version;
     withAutoReconf = false;
     stdenv = if stdenv.cc.isGNU then gcc49Stdenv else stdenv;
     patches = [ ./patches/all-dso-handle.patch ./patches/fpending-24.3.patch ] ++ fixMacosUnexecPatches;
   };
 
   emacs-24-4 = with pkgs; callPackage ./emacs.nix {
-    inherit (release "24.4" "1iicqcijr56r7vxxm3v3qhf69xpxlpq7afbjr6h6bpjsz8d4yg59") name src;
+    inherit (release "24.4" "1iicqcijr56r7vxxm3v3qhf69xpxlpq7afbjr6h6bpjsz8d4yg59") name src version;
     withAutoReconf = false;
     stdenv = if stdenv.cc.isGNU then gcc49Stdenv else stdenv;
     patches = [ ./patches/gnutls-e_again.patch ] ++ fixMacosUnexecPatches;
   };
 
   emacs-24-5 = with pkgs; callPackage ./emacs.nix {
-    inherit (release "24.5" "1dn3jx1dph5wr47v97g0fhka9gcpn8pnzys7khp9indj5xiacdr7") name src;
+    inherit (release "24.5" "1dn3jx1dph5wr47v97g0fhka9gcpn8pnzys7khp9indj5xiacdr7") name src version;
     withAutoReconf = false;
     stdenv = if stdenv.cc.isGNU then gcc49Stdenv else stdenv;
     patches = [ ./patches/gnutls-e_again.patch ] ++ fixMacosUnexecPatches;
   };
 
   emacs-25-1 = pkgs.callPackage ./emacs.nix {
-    inherit (release "25.1" "0rqw9ama0j5b6l4czqj4wlf21gcxi9s18p8cx6ghxm5l1nwl8cvn") name src;
+    inherit (release "25.1" "0rqw9ama0j5b6l4czqj4wlf21gcxi9s18p8cx6ghxm5l1nwl8cvn") name src version;
     withAutoReconf = true;
     patches = [
       ./patches/gnutls-use-osx-cert-bundle.patch
@@ -91,7 +92,7 @@ in
   };
 
   emacs-25-2 = pkgs.callPackage ./emacs.nix {
-    inherit (release "25.2" "0b9dwx6nxzflaipkgml4snny2c3brgy0py6h05q995y1lrpbsnsh") name src;
+    inherit (release "25.2" "0b9dwx6nxzflaipkgml4snny2c3brgy0py6h05q995y1lrpbsnsh") name src version;
     withAutoReconf = true;
     patches = [
       ./patches/gnutls-use-osx-cert-bundle.patch
@@ -100,7 +101,7 @@ in
   };
 
   emacs-25-3 = pkgs.callPackage ./emacs.nix {
-    inherit (release "25.3" "1jc3g79nrcix0500kiw6hqpql82ajq0xivlip6iaryxn90dnlb7p") name src;
+    inherit (release "25.3" "1jc3g79nrcix0500kiw6hqpql82ajq0xivlip6iaryxn90dnlb7p") name src version;
     withAutoReconf = true;
     patches = [
       ./patches/gnutls-use-osx-cert-bundle.patch
@@ -109,30 +110,31 @@ in
   };
 
   emacs-26-1 = pkgs.callPackage ./emacs.nix {
-    inherit (release "26.1" "18vaqn7y7c39as4bn95yfcabwvqkw6y59xz8g78d1ifdx3aq40vn") name src;
+    inherit (release "26.1" "18vaqn7y7c39as4bn95yfcabwvqkw6y59xz8g78d1ifdx3aq40vn") name src version;
     withAutoReconf = true;
     patches = [ ./patches/gnutls-e_again.patch ] ++ fixMacosUnexecPatches;
   };
 
   emacs-26-2 = pkgs.callPackage ./emacs.nix {
-    inherit (release "26.2" "1sxl0bqwl9b62nswxaiqh1xa61f3hng4fmyc69lmadx770mfb6ag") name src;
+    inherit (release "26.2" "1sxl0bqwl9b62nswxaiqh1xa61f3hng4fmyc69lmadx770mfb6ag") name src version;
     withAutoReconf = true;
     patches = [ ./patches/gnutls-e_again.patch ] ++ fixMacosUnexecPatches;
   };
 
   emacs-26-3 = pkgs.callPackage ./emacs.nix {
-    inherit (release "26.3" "14bm73758w6ydxlvckfy9nby015p20lh2yvl6pnrjz0k93h4giq9") name src;
+    inherit (release "26.3" "14bm73758w6ydxlvckfy9nby015p20lh2yvl6pnrjz0k93h4giq9") name src version;
     withAutoReconf = true;
     patches = fixMacosUnexecPatches;
   };
 
   emacs-27-1 = pkgs.callPackage ./emacs.nix {
-    inherit (release "27.1" "1nw4lpid1kqncypa9f1228d43m59qn3gqgmy3vrjrfair4fsdgzz") name src;
+    inherit (release "27.1" "1nw4lpid1kqncypa9f1228d43m59qn3gqgmy3vrjrfair4fsdgzz") name src version;
     withAutoReconf = true;
   };
 
   emacs-snapshot = pkgs.callPackage ./emacs.nix {
     inherit (snapshot "0d0aad213f941efc0fa0ec032e37dc9c2b08c9fb" "041q0k58qfw2fjz6j9zf152jhkzn8zc8xg35aprxhndinf1cakml") name src;
+    version = "28.0.50";
     srcRepo = true;
     withAutoReconf = true;
   };

--- a/emacs.nix
+++ b/emacs.nix
@@ -1,5 +1,6 @@
 { name
 , src
+, version
 , stdenv
 , lib
 , fetchurl
@@ -29,7 +30,7 @@ in
 
   # A very minimal version of https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/emacs/default.nix
 stdenv.mkDerivation rec {
-  inherit name src;
+  inherit name version src;
 
   enableParallelBuilding = true;
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,0 +1,12 @@
+{ emacsAttr
+}:
+let
+  pkgs = import (import ../nix/sources.nix).nixpkgs {};
+  emacs = (import ../default.nix).${emacsAttr};
+in
+(pkgs.emacsPackagesFor emacs).emacsWithPackages (
+  epkgs: [
+    epkgs.seq
+    epkgs.dash
+  ]
+)


### PR DESCRIPTION
For low-level usage, a canonical version is sometimes required in the Emacs derivation: https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/emacs-modes/elpa-packages.nix#L53.

I've added a test, but the current Nix infrastructure for Emacs fails to build packages on Emacs 24.3 (https://github.com/akirak/elinter/issues/29), so I've added a skip condition.
