### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "chore"
+    include: "scope"


### PR DESCRIPTION
This automates PRs for bumping GitHub Actions (like #30). It is basically stolen from the repository of [pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix/blob/master/.github/dependabot.yml).