### PR TITLE
Pass system explicitly to allow pure evaluation

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,6 +1,6 @@
 self: super:
 let
-  sources = import ./nix/sources.nix;
+  sources = import ./nix/sources.nix { inherit (super) system; };
 
   source_for = version: rec {
     inherit version;


### PR DESCRIPTION
Hello, 

Since adoption of niv for tracking sources in nix-emacs-ci (16c43b7ac04b3febfb43389f14e72815fdb4d185), I cannot use the overlay in a Nix flake.

The error message is as follows:

> error: attribute 'currentSystem' missing
>        at /nix/store/2iz88y66ln6yfhr4k2nlr50535g64fz2-source/nix/sources.nix:165:16:
>           164|     , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
>           165|     , system ? builtins.currentSystem
>              |                ^
>           166|     , pkgs ? mkPkgs sources system
> (use '--show-trace' to show detailed location information)

This is because `builtins.currentSystem` is not allowed in pure evaluation mode, which is the default in flakes.

To prevent this error, you can pass the system explicitly, as in this PR. This API seems to be safe to use (see https://github.com/nmattia/niv/issues/134#issuecomment-549934347), and even it it is not, you can easily rollback the change.

To reproduce the error, you can create the following `flake.nix` in a Git repository:

```nix
{
  description = "Minimal flake project";

  inputs.emacs-ci = {
    url = "github:purcell/nix-emacs-ci";
    flake = false;
  };

  outputs = {
    self,
    nixpkgs,
    flake-utils,
    emacs-ci,
  }:
    flake-utils.lib.eachDefaultSystem
    (system: let
      pkgs = import nixpkgs {
        inherit system;
        overlays = [
          (import (emacs-ci + "/overlay.nix"))
        ];
      };
    in {
      packages = flake-utils.lib.flattenTree {
        default = pkgs.emacs-snapshot;
      };
    });
}
```

When you run `nix build`, it throws the error.

When you run the following command, it successfully builds:

```sh
nix build --override-input emacs-ci github:akirak/nix-emacs-ci/pure-eval
```
