### PR TITLE
Test if packages are loadable with the wrapper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,4 @@ jobs:
         nix-build --argstr emacsAttr emacs-${{ matrix.attr }} tests \
          && result/bin/test
       if: ${{ ! contains( fromJson('[ "23-4", "24-1", "24-2", "24-3", "24-4", "24-5" ]'), matrix.attr ) }}
-      name: Test low-level Nix usage
+      name: Test if the wrapper builds a configuration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
         cd tests && HOME=$(mktemp -d) ../result/bin/emacs -Q --batch \
         --eval "(setq debug-on-error t)" --load init.el
       name: Test if package.el works inside Emacs
-    - run: nix-build --argstr emacsAttr emacs-${{ matrix.attr }} tests
+    - run: |
+        nix-build --argstr emacsAttr emacs-${{ matrix.attr }} tests \
+         && result/bin/test
       if: ${{ ! contains( fromJson('[ "23-4", "24-1", "24-2", "24-3", "24-4", "24-5" ]'), matrix.attr ) }}
       name: Test low-level Nix usage

--- a/emacs.nix
+++ b/emacs.nix
@@ -91,6 +91,12 @@ stdenv.mkDerivation rec {
 
   installTargets = "tags install";
 
+  # Create site-start.el which is needed by the wrapper
+  postInstall = ''
+    mkdir -p $out/share/emacs/site-lisp
+    touch $out/share/emacs/site-lisp/site-start.el
+  '';
+
   meta = with lib; {
     description = "The extensible, customizable GNU text editor";
     homepage = https://www.gnu.org/software/emacs/;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,12 +1,28 @@
-{ emacsAttr
-}:
-let
-  pkgs = import (import ../nix/sources.nix).nixpkgs { overlays = [ (import ../overlay.nix) ]; };
-  emacs = (import ../default.nix).${emacsAttr};
+{emacsAttr ? null}: let
+  pkgs = import (import ../nix/sources.nix).nixpkgs {
+    overlays = [(import ../overlay.nix)];
+  };
+  emacs =
+    if emacsAttr == null
+    then pkgs.emacs
+    else (import ../default.nix).${emacsAttr};
 in
-(pkgs.emacsPackagesFor emacs).emacsWithPackages (
-  epkgs: [
-    epkgs.seq
-    epkgs.dash
-  ]
-)
+  pkgs.writeShellApplication {
+    name = "test";
+    runtimeInputs = [
+      ((pkgs.emacs.pkgs.overrideScope' (_: _: {
+          inherit emacs;
+        }))
+        .withPackages (
+          epkgs: [
+            epkgs.seq
+            epkgs.dash
+          ]
+        ))
+    ];
+    text = ''
+      emacs --version
+      emacs -batch -q -l seq -l dash
+      echo "Successfully loaded."
+    '';
+  }


### PR DESCRIPTION
The test which I added three years ago only builds `emacsWithPackages` wrapper with a few packages. Since then, there have been several changes made in the upstream nixpkgs repository. Unfortunately, the wrapper no longer correctly starts if it is combined with an Emacs derivation from `nix-emacs-ci`, which was not detected by the test.

This PR extends the test to check if the wrapper correctly starts and loads packages.