### PR TITLE
Follow up the recent API change in nixpkgs

### DIFF
--- a/emacs.nix
+++ b/emacs.nix
@@ -13,7 +13,7 @@
 , gnutls
 , jansson
 , tree-sitter
-, treeSitter ? false
+, withTreeSitter ? false
 , gmp
 , sigtool ? null
 , autoconf ? null
@@ -44,14 +44,14 @@ stdenv.mkDerivation rec {
     ++ lib.optionals srcRepo [ autoconf automake texinfo ];
 
   buildInputs =
-    [ ncurses libxml2 gnutls gettext jansson gmp ] ++ lib.optionals stdenv.isDarwin [ sigtool ] ++ lib.optional treeSitter tree-sitter;
+    [ ncurses libxml2 gnutls gettext jansson gmp ] ++ lib.optionals stdenv.isDarwin [ sigtool ] ++ lib.optional withTreeSitter tree-sitter;
 
   hardeningDisable = [ "format" ];
 
   inherit patches;
 
   passthru = {
-    inherit treeSitter;
+    inherit withTreeSitter;
   };
 
   configureFlags = [

--- a/overlay.nix
+++ b/overlay.nix
@@ -167,7 +167,7 @@ let
       version = "29.0.60";
       srcRepo = true;
       withAutoReconf = true;
-      treeSitter = true;
+      withTreeSitter = true;
       inherit (self.darwin) sigtool;
     };
 
@@ -176,7 +176,7 @@ let
       version = "30.0.50";
       srcRepo = true;
       withAutoReconf = true;
-      treeSitter = true;
+      withTreeSitter = true;
       inherit (self.darwin) sigtool;
     };
   };


### PR DESCRIPTION
Due to recent minor API changes in NixOS/nixpkgs#235859, you will need this PR next time you update nixpkgs in this repository. Please don't merge this PR right now, unless you have decided to perform the update ahead your cycle.