### PR TITLE
Fix regression of the tree-sitter support

### DIFF
--- a/emacs.nix
+++ b/emacs.nix
@@ -13,7 +13,7 @@
 , gnutls
 , jansson
 , tree-sitter
-, withTreeSitter ? false
+, withTreeSitter ? lib.versionAtLeast version "29"
 , gmp
 , sigtool ? null
 , autoconf ? null

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -23,5 +23,11 @@ pkgs.writeShellApplication {
     emacs --version
     emacs -batch -q -l seq -l dash
     echo "Successfully loaded."
+    emacs -batch -q --eval \
+      '(when (version< "29" emacs-version)
+         (if (treesit-available-p)
+            (message "treesit is available.")
+           (message "treesit is unavailable.")
+           (kill-emacs 1)))'
   '';
 }


### PR DESCRIPTION
This was an oversight in #183, but the option must be dependent on the Emacs version.