### PR TITLE
Bump emacs-release-snapshot to 29.1.90

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
                 emacs-28-1 = "28.1";
                 emacs-28-2 = "28.2";
                 emacs-29-1 = "29.1";
-                emacs-release-snapshot = "29.0.60";
+                emacs-release-snapshot = "29.1.90";
                 emacs-snapshot = "30.0.50";
               };
           in


### PR DESCRIPTION
`emacs-release-snapshot` has been recently bumped from `29.1.50` to `29.1.90`. The version string is outdated, so I'll send a PR.

I track information on Emacs versions by periodically running a CI job in [this repository](https://github.com/emacs-twist/emacs-builtins). You can print the version numbers (as retrieved by running `emacs --version`) using the following command:

```
nix eval github:emacs-twist/emacs-builtins#data --no-write-lock-file --json --apply 'builtins.mapAttrs (_: { version, ...}: version)' | jq
```