### PR TITLE
Workaround for macOS builds with recent nixpkgs

### DIFF
--- a/emacs.nix
+++ b/emacs.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  dontStrip = stdenv.isDarwin && lib.versionOlder version "27.1";
+
   patches =
     lib.optionals ("23.4" == version) [
       ./patches/all-dso-handle.patch

--- a/flake.lock
+++ b/flake.lock
@@ -272,11 +272,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698553279,
-        "narHash": "sha256-T/9P8yBSLcqo/v+FTOBK+0rjzjPMctVymZydbvR/Fak=",
+        "lastModified": 1704008649,
+        "narHash": "sha256-rGPSWjXTXTurQN9beuHdyJhB8O761w1Zc5BqSSmHvoM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90e85bc7c1a6fc0760a94ace129d3a1c61c3d035",
+        "rev": "d44d59d2b5bd694cd9d996fd8c51d03e3e9ba7f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Issue introduced by https://github.com/NixOS/nixpkgs/commit/bcbdb800cf7659d6ff36ac114121a056fe8c9656

See notes in #233