### PR TITLE
Adjust Actions platform mapping now Apple Silicon runners are available

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,8 @@
         inherit (builtins) attrValues mapAttrs attrNames map concatLists intersectAttrs;
         platforms = {
           "x86_64-linux" = "ubuntu-latest";
-          "x86_64-darwin" = "macos-latest";
+          "x86_64-darwin" = "macos-11";
+          "aarch64-darwin" = "macos-14";
         };
       in
       rec {


### PR DESCRIPTION
See #267 — `macos-latest` is [apparently now using M1](https://github.com/orgs/community/discussions/102846), so we should populate the Nix cache by building there. Older Emacsen cannot be built on ARM MacOS. We continue to use macos-11 to perform and cache Intel Mac builds for the previous wider range of Emacs version.