### PR TITLE
Update emacs-release-snapshot to emacs-30 branch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
       flake = false;
     };
     emacs-release-snapshot = {
-      url = "github:emacs-mirror/emacs?ref=emacs-29";
+      url = "github:emacs-mirror/emacs?ref=emacs-30";
       flake = false;
     };
   };
@@ -141,7 +141,7 @@
             emacs-29-2 = "29.2";
             emacs-29-3 = "29.3";
             emacs-29-4 = "29.4";
-            emacs-release-snapshot = "29.4.50";
+            emacs-release-snapshot = "30.0.60";
             emacs-snapshot = "31.0.50";
           };
       in builtins.mapAttrs (name: version:


### PR DESCRIPTION
This is a follow up to #286 and updates `emacs-release-snapshot` to the new highest-numbered release branch.