### PR TITLE
Ensure flake is locked at start of CI run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,19 @@ on:
       - master
 
 jobs:
+  relock:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@V27
+    - run: nix flake lock
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: Update flake.lock
+        file_pattern: flake.lock
+
   nix-matrix:
+    needs: relock
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
What do you think of this, @akirak?

Maybe it's more trouble than it's worth, but it wasn't obvious how we could automatically verify that the flake.lock is not out of sync.