### PR TITLE
Patch Emacsen < 27 to use the newer logic for when package-check-signature is t

### DIFF
--- a/emacs.nix
+++ b/emacs.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals
     (lib.versionAtLeast version "24.3" && lib.versionOlder version "26.3")
     [ ./patches/gnutls-e_again.patch ] ++ lib.optionals
+    (lib.versionAtLeast version "25.1" && lib.versionOlder version "27.1")
+    [ ./patches/package-check-signature-all.patch ] ++ lib.optionals
     (lib.versionAtLeast version "25.1" && lib.versionOlder version "28.1")
     [ ./patches/sigsegv-stack.patch ] ++ lib.optionals (stdenv.isDarwin
       && lib.versionAtLeast version "25.1" && lib.versionOlder version "26.1")

--- a/patches/package-check-signature-all.patch
+++ b/patches/package-check-signature-all.patch
@@ -1,0 +1,44 @@
+Based on upstream commit 3c1967dbfe06b28ac074aee1e55a79bacfc36f8d
+
+diff --git a/lisp/emacs-lisp/package.el b/lisp/emacs-lisp/package.el
+index 61cf6906971..949ad711ae3 100644
+--- a/lisp/emacs-lisp/package.el
++++ b/lisp/emacs-lisp/package.el
+@@ -334,16 +334,22 @@ default directory."
+            (epg-find-configuration 'OpenPGP))
+       'allow-unsigned)
+   "Non-nil means to check package signatures when installing.
+-The value `allow-unsigned' means to still install a package even if
+-it is unsigned.
++More specifically the value can be:
++- nil: package signatures are ignored.
++- `allow-unsigned': install a package even if it is unsigned,
++  but if it is signed and we have the key for it, verify the signature.
++- t: accept a package only if it comes with at least one verified signature.
++- `all': same as t, except when the package has several signatures,
++  in which case we verify all the signatures.
+ 
+ This also applies to the \"archive-contents\" file that lists the
+ contents of the archive."
+   :type '(choice (const nil :tag "Never")
+                  (const allow-unsigned :tag "Allow unsigned")
+-                 (const t :tag "Check always"))
++                 (const t :tag "Check always")
++                 (const all :tag "Check all signatures"))
+   :risky t
+-  :version "24.4")
++  :version "27.1")
+ 
+ (defcustom package-unsigned-archives nil
+   "List of archives where we do not check for package signatures."
+@@ -1257,7 +1263,9 @@ errors."
+           (unless (and (eq package-check-signature 'allow-unsigned)
+                        (eq (epg-signature-status sig) 'no-pubkey))
+             (setq had-fatal-error t))))
+-      (when (or (null good-signatures) had-fatal-error)
++      (when (or (null good-signatures)
++                (and (eq package-check-signature 'all)
++                     had-fatal-error))
+         (package--display-verify-error context sig-file)
+         (signal 'bad-signature (list sig-file)))
+       good-signatures)))


### PR DESCRIPTION
Older Emacsen checked that *all* signatures for a package are valid, but t now means "at least one signature is valid". Old keys have been removed from the newer package signing keyrings, but are apparently still being used to sign packages, hence old Emacsen reported errors.

https://github.com/Silex/docker-emacs/issues/104