### PR TITLE
Bump the release snapshot to 30.0.90

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,7 @@
             emacs-29-2 = "29.2";
             emacs-29-3 = "29.3";
             emacs-29-4 = "29.4";
-            emacs-release-snapshot = "30.0.60";
+            emacs-release-snapshot = "30.0.90";
             emacs-snapshot = "31.0.50";
           };
       in builtins.mapAttrs (name: version:


### PR DESCRIPTION
`emacs-30` branch has been bumped to 30.0.90, so we'll update the version accordingly.

> $ nix shell github:purcell/nix-emacs-ci#emacs-release-snapshot
$ emacs --version                                                                      
GNU Emacs 30.0.90
Copyright (C) 2024 Free Software Foundation, Inc.
GNU Emacs comes with ABSOLUTELY NO WARRANTY.
You may redistribute copies of GNU Emacs
under the terms of the GNU General Public License.
For more information about these matters, see the file named COPYING.