### PR TITLE
Drop Emacs versions that depend on obsolete gcc49Stdenv

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725099143,
-        "narHash": "sha256-CHgumPZaC7z+WYx72WgaLt2XF0yUVzJS60rO4GZ7ytY=",
+        "lastModified": 1727716680,
+        "narHash": "sha256-uMVkVHL4r3QmlZ1JM+UoJwxqa46cgHnIfqGzVlw5ca4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5629520edecb69630a3f4d17d3d33fc96c13f6fe",
+        "rev": "b5b22b42c0d10c7d2463e90a546c394711e3a724",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -118,14 +118,11 @@
         versions =
           # Some versions do not currently build on MacOS, so we do not even
           # expose them on that platform.
-          (lib.optionalAttrs pkgs.stdenv.isLinux {
-            emacs-23-4 = "23.4";
-            emacs-24-1 = "24.1";
-            emacs-24-2 = "24.2";
-          }) // (lib.optionalAttrs (system != "aarch64-darwin") {
+          (lib.optionalAttrs (system != "aarch64-darwin" && ! pkgs.stdenv.cc.isGNU) {
             emacs-24-3 = "24.3";
             emacs-24-4 = "24.4";
             emacs-24-5 = "24.5";
+          }) // (lib.optionalAttrs (system != "aarch64-darwin") {
             emacs-25-1 = "25.1";
             emacs-25-2 = "25.2";
             emacs-25-3 = "25.3";
@@ -151,10 +148,6 @@
           src = inputs.${name};
           latestPackageKeyring = inputs.emacs-snapshot
             + "/etc/package-keyring.gpg";
-          stdenv = if lib.versionOlder version "25" && pkgs.stdenv.cc.isGNU then
-            pkgs.gcc49Stdenv
-          else
-            pkgs.stdenv;
           srcRepo = lib.strings.hasInfix "snapshot" version;
         }) versions);
 


### PR DESCRIPTION
See #311.