### PR TITLE
Update on deprecation of gcc49Stdenv

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725099143,
-        "narHash": "sha256-CHgumPZaC7z+WYx72WgaLt2XF0yUVzJS60rO4GZ7ytY=",
+        "lastModified": 1727716680,
+        "narHash": "sha256-uMVkVHL4r3QmlZ1JM+UoJwxqa46cgHnIfqGzVlw5ca4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5629520edecb69630a3f4d17d3d33fc96c13f6fe",
+        "rev": "b5b22b42c0d10c7d2463e90a546c394711e3a724",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -151,10 +151,6 @@
           src = inputs.${name};
           latestPackageKeyring = inputs.emacs-snapshot
             + "/etc/package-keyring.gpg";
-          stdenv = if lib.versionOlder version "25" && pkgs.stdenv.cc.isGNU then
-            pkgs.gcc49Stdenv
-          else
-            pkgs.stdenv;
           srcRepo = lib.strings.hasInfix "snapshot" version;
         }) versions);
 


### PR DESCRIPTION
This is another take on #311, which tries not to drop support for the old Emacs versions.

Closes #311 and #310