### PR TITLE
Update on deprecation of overrideScope'

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,7 +1,7 @@
 { lib, emacs, ciEmacs, writeShellApplication }:
 let
   canDoPackages = lib.versionAtLeast ciEmacs.version "25.1";
-  ciEmacsWithPackages = (emacs.pkgs.overrideScope' (_: _: {
+  ciEmacsWithPackages = (emacs.pkgs.overrideScope (_: _: {
     emacs = ciEmacs;
   })).withPackages (
     epkgs: [


### PR DESCRIPTION
Recently, the deprecated `overrideScope'` function has been completely removed from nixpkgs (see https://github.com/NixOS/nixpkgs/commit/af10dd201409ca9ba396507544f35d9dbaea2e98), which makes #325 fail. The function is now simply `overrideScope` without prime.