### PR TITLE
Remove Intel MacOS from CI and, therefore, the binary cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -170,7 +170,7 @@
         attrValues mapAttrs attrNames map concatLists intersectAttrs;
       platforms = {
         "x86_64-linux" = "ubuntu-latest";
-        "x86_64-darwin" = "macos-latest";
+        #"x86_64-darwin" = "macos-latest";
         "aarch64-darwin" = "macos-latest";
       };
     in rec {


### PR DESCRIPTION
This is primarily a space-saving measure, since our binary cache appears to be so large that essential items are getting evicted.

See https://github.com/purcell/setup-emacs/issues/53