### PR TITLE
Disable fail-fast on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
+      fail-fast: false
     timeout-minutes: 30 # Safety net in case of hanging executable
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

#374 seems still relevant, and random failures occur. To reduce manual reruns,
disable fail fast to build as many targets as possible.
