### PR TITLE
Set always-allow-subsitutes option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v32
+        with:
+          nix_conf: |
+            always-allow-substitutes = true
       - uses: cachix/cachix-action@v16
         with:
           name: emacs-ci


### PR DESCRIPTION
The CI fetches release tarballs from ftp.gnu.org, without downloading them from cachix. I will open this PR to see if #374 can be resolved with this option.