### PR TITLE
Disable useDaemon option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           name: emacs-ci
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+          useDaemon: false
       - run: nix build --accept-flake-config --system ${{matrix.system}} -L ".#githubActions.checks.${{matrix.system}}.${{ matrix.attr }}"
       - name: Test if package.el works inside Emacs
         run: cd tests && HOME=$(pwd) nix run --accept-flake-config --system ${{matrix.system}} "..#githubActions.checks.${{matrix.system}}.${{ matrix.attr }}" -- -Q --batch \


### PR DESCRIPTION
To push all paths to cachix, switch from the daemon mode to the store scan mode. See https://github.com/cachix/cachix-action/?tab=readme-ov-file#push-modes for details.