### PR TITLE
Add tree-sitter-jsdoc build dependency

### DIFF
--- a/emacs.nix
+++ b/emacs.nix
@@ -20,7 +20,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses libxml2 gnutls gettext jansson gmp ]
     ++ lib.optional withSQLite3 sqlite
-    ++ lib.optional withTreeSitter tree-sitter;
+    ++ lib.optional withTreeSitter (tree-sitter.withPlugins (p:
+      lib.optionals (lib.versionAtLeast version "31") [
+        p.tree-sitter-jsdoc
+      ]));
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
This PR fixes the following error on emacs-snapshot (#391):

> emacs-snapshot>   ELC      progmodes/sql.elc
emacs-snapshot>   ELC      progmodes/subword.elc
emacs-snapshot>   ELC      progmodes/tcl.elc
emacs-snapshot>   ELC      progmodes/typescript-ts-mode.elc
emacs-snapshot> Tree-sitter grammar for `jsdoc' is missing; install it? (y or n)
emacs-snapshot> In toplevel form:
emacs-snapshot> progmodes/php-ts-mode.el:72:11: Error: End of file during parsing: Error reading from stdin

`tree-sitter-jsdoc` is required at build time due to the following code in `php-ts-mode` (see https://github.com/emacs-mirror/emacs/commit/bd62f57efd3206fc5764e9e592206be820002500):

```elisp
(treesit-ensure-installed 'jsdoc)
```