### PR TITLE
Support for tree-sitter 0.26

### DIFF
--- a/emacs.nix
+++ b/emacs.nix
@@ -97,6 +97,9 @@ stdenv.mkDerivation rec {
     ) [ ./patches/gnutls-use-osx-cert-bundle.patch ]
     ++ lib.optionals (stdenv.isDarwin && lib.versionOlder version "27.1") [
       ./patches/macos-unexec.patch
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "29.1" && lib.versionOlder version "31.0") [
+      ./patches/tree-sitter-0.26.patch
     ];
 
   passthru = { inherit withTreeSitter; };

--- a/emacs.nix
+++ b/emacs.nix
@@ -100,6 +100,15 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals (lib.versionAtLeast version "29.1" && lib.versionOlder version "31.0") [
       ./patches/tree-sitter-0.26.patch
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "29.1" && lib.versionOlder version "30.1") [
+      ./patches/tree-sitter-query-29.patch
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "30.1" && lib.versionOlder version "30.2") [
+      ./patches/tree-sitter-query-30.1.patch
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "30.2" && lib.versionOlder version "31.0") [
+      ./patches/tree-sitter-query-30.2.patch
     ];
 
   passthru = { inherit withTreeSitter; };

--- a/flake.lock
+++ b/flake.lock
@@ -337,11 +337,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774855581,
-        "narHash": "sha256-YkreHeMgTCYvJ5fESV0YyqQK49bHGe2B51tH6claUh4=",
+        "lastModified": 1777425547,
+        "narHash": "sha256-d57AbflkNfZNoFaZDzssEq1RfPoM9dLtOGI2O+N/68Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "15c6719d8c604779cf59e03c245ea61d3d7ab69b",
+        "rev": "ebc08544afa77957cc348ba72dc490ec73b87f68",
         "type": "github"
       },
       "original": {

--- a/patches/tree-sitter-0.26.patch
+++ b/patches/tree-sitter-0.26.patch
@@ -2,55 +2,43 @@ diff --git a/src/treesit.c b/src/treesit.c
 index bf982de580..69751b5ea1 100644
 --- a/src/treesit.c
 +++ b/src/treesit.c
-@@ -35,7 +35,11 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+@@ -35,7 +35,7 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
  # include "w32common.h"
  
  /* In alphabetical order.  */
-+#if TREE_SITTER_LANGUAGE_VERSION >= 15
 +#undef ts_language_abi_version
-+#else
- #undef ts_language_version
-+#endif
+-#undef ts_language_version
  #undef ts_node_child
  #undef ts_node_child_by_field_name
  #undef ts_node_child_count
-@@ -90,7 +94,11 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+@@ -90,7 +94,7 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
  #undef ts_tree_get_changed_ranges
  #undef ts_tree_root_node
  
-+#if TREE_SITTER_LANGUAGE_VERSION >= 15
 +DEF_DLL_FN (uint32_t, ts_language_abi_version, (const TSLanguage *));
-+#else
- DEF_DLL_FN (uint32_t, ts_language_version, (const TSLanguage *));
-+#endif
+-DEF_DLL_FN (uint32_t, ts_language_version, (const TSLanguage *));
  DEF_DLL_FN (TSNode, ts_node_child, (TSNode, uint32_t));
  DEF_DLL_FN (TSNode, ts_node_child_by_field_name,
  	    (TSNode, const char *, uint32_t));
-@@ -167,7 +175,11 @@ init_treesit_functions (void)
+@@ -167,7 +175,7 @@ init_treesit_functions (void)
    if (!library)
      return false;
  
-+#if TREE_SITTER_LANGUAGE_VERSION >= 15
 +  LOAD_DLL_FN (library, ts_language_abi_version);
-+#else
-   LOAD_DLL_FN (library, ts_language_version);
-+#endif
+-  LOAD_DLL_FN (library, ts_language_version);
    LOAD_DLL_FN (library, ts_node_child);
    LOAD_DLL_FN (library, ts_node_child_by_field_name);
    LOAD_DLL_FN (library, ts_node_child_count);
-@@ -225,7 +237,11 @@ init_treesit_functions (void)
+@@ -225,7 +237,7 @@ init_treesit_functions (void)
    return true;
  }
  
-+#if TREE_SITTER_LANGUAGE_VERSION >= 15
 +#define ts_language_abi_version fn_ts_language_abi_version
-+#else
- #define ts_language_version fn_ts_language_version
-+#endif
+-#define ts_language_version fn_ts_language_version
  #define ts_node_child fn_ts_node_child
  #define ts_node_child_by_field_name fn_ts_node_child_by_field_name
  #define ts_node_child_count fn_ts_node_child_count
-@@ -711,6 +727,22 @@ treesit_load_language_push_for_each_suffix (Lisp_Object lib_base_name,
+@@ -711,6 +727,18 @@ treesit_load_language_push_for_each_suffix (Lisp_Object lib_base_name,
      }
  }
  
@@ -63,11 +51,7 @@ index bf982de580..69751b5ea1 100644
 +static uint32_t
 +treesit_language_abi_version (const TSLanguage *ts_lang)
 +{
-+#if TREE_SITTER_LANGUAGE_VERSION >= 15
 +  return ts_language_abi_version (ts_lang);
-+#else
-+  return ts_language_version (ts_lang);
-+#endif
 +}
 +
  /* Load the dynamic library of LANGUAGE_SYMBOL and return the pointer

--- a/patches/tree-sitter-0.26.patch
+++ b/patches/tree-sitter-0.26.patch
@@ -73,15 +73,6 @@ index bf982de580..69751b5ea1 100644
  /* Load the dynamic library of LANGUAGE_SYMBOL and return the pointer
     to the language definition.
  
-@@ -832,7 +864,7 @@ treesit_load_language (Lisp_Object language_symbol,
- 	build_string ("%s's ABI version is %d, but supported versions are %d-%d");
-       Lisp_Object formatted_msg =
- 	CALLN (Fformat_message, fmt, loaded_lib,
--	       make_fixnum (ts_language_version (lang)),
-+	       make_fixnum (treesit_language_abi_version (lang)),
- 	       make_fixnum (TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION),
- 	       make_fixnum (TREE_SITTER_LANGUAGE_VERSION));
-       *signal_symbol = Qtreesit_load_language_error;
 @@ -914,7 +946,7 @@ Return nil if a grammar library for LANGUAGE is not available.  */)
        TSLanguage *ts_language = lang.lang;
        if (ts_language == NULL)
@@ -91,3 +82,16 @@ index bf982de580..69751b5ea1 100644
        return make_fixnum((ptrdiff_t) version);
      }
  }
+diff --git a/src/treesit.c b/src/treesit.c
+index bffd42da12..ad75ae0820 100644
+--- a/src/treesit.c
++++ b/src/treesit.c
+@@ -692,7 +692,7 @@ treesit_load_language (Lisp_Object language_symbol,
+     {
+       *signal_symbol = Qtreesit_load_language_error;
+       *signal_data = list2 (Qversion_mismatch,
+-			    make_fixnum (ts_language_version (lang)));
++			    make_fixnum (ts_language_abi_version (lang)));
+       return NULL;
+     }
+   return lang;

--- a/patches/tree-sitter-0.26.patch
+++ b/patches/tree-sitter-0.26.patch
@@ -1,0 +1,93 @@
+diff --git a/src/treesit.c b/src/treesit.c
+index bf982de580..69751b5ea1 100644
+--- a/src/treesit.c
++++ b/src/treesit.c
+@@ -35,7 +35,11 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+ # include "w32common.h"
+ 
+ /* In alphabetical order.  */
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++#undef ts_language_abi_version
++#else
+ #undef ts_language_version
++#endif
+ #undef ts_node_child
+ #undef ts_node_child_by_field_name
+ #undef ts_node_child_count
+@@ -90,7 +94,11 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+ #undef ts_tree_get_changed_ranges
+ #undef ts_tree_root_node
+ 
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++DEF_DLL_FN (uint32_t, ts_language_abi_version, (const TSLanguage *));
++#else
+ DEF_DLL_FN (uint32_t, ts_language_version, (const TSLanguage *));
++#endif
+ DEF_DLL_FN (TSNode, ts_node_child, (TSNode, uint32_t));
+ DEF_DLL_FN (TSNode, ts_node_child_by_field_name,
+ 	    (TSNode, const char *, uint32_t));
+@@ -167,7 +175,11 @@ init_treesit_functions (void)
+   if (!library)
+     return false;
+ 
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++  LOAD_DLL_FN (library, ts_language_abi_version);
++#else
+   LOAD_DLL_FN (library, ts_language_version);
++#endif
+   LOAD_DLL_FN (library, ts_node_child);
+   LOAD_DLL_FN (library, ts_node_child_by_field_name);
+   LOAD_DLL_FN (library, ts_node_child_count);
+@@ -225,7 +237,11 @@ init_treesit_functions (void)
+   return true;
+ }
+ 
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++#define ts_language_abi_version fn_ts_language_abi_version
++#else
+ #define ts_language_version fn_ts_language_version
++#endif
+ #define ts_node_child fn_ts_node_child
+ #define ts_node_child_by_field_name fn_ts_node_child_by_field_name
+ #define ts_node_child_count fn_ts_node_child_count
+@@ -711,6 +727,22 @@ treesit_load_language_push_for_each_suffix (Lisp_Object lib_base_name,
+     }
+ }
+ 
++/* This function is a compatibility shim.  Tree-sitter 0.25 introduced
++   ts_language_abi_version as a replacement for ts_language_version, and
++   tree-sitter 0.26 removed ts_language_version.  Here we use the fact
++   that 0.25 bumped TREE_SITTER_LANGUAGE_VERSION to 15, to use the new
++   function instead of the old one, when Emacs is compiled against
++   tree-sitter version 0.25 or newer.  */
++static uint32_t
++treesit_language_abi_version (const TSLanguage *ts_lang)
++{
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++  return ts_language_abi_version (ts_lang);
++#else
++  return ts_language_version (ts_lang);
++#endif
++}
++
+ /* Load the dynamic library of LANGUAGE_SYMBOL and return the pointer
+    to the language definition.
+ 
+@@ -832,7 +864,7 @@ treesit_load_language (Lisp_Object language_symbol,
+ 	build_string ("%s's ABI version is %d, but supported versions are %d-%d");
+       Lisp_Object formatted_msg =
+ 	CALLN (Fformat_message, fmt, loaded_lib,
+-	       make_fixnum (ts_language_version (lang)),
++	       make_fixnum (treesit_language_abi_version (lang)),
+ 	       make_fixnum (TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION),
+ 	       make_fixnum (TREE_SITTER_LANGUAGE_VERSION));
+       *signal_symbol = Qtreesit_load_language_error;
+@@ -914,7 +946,7 @@ Return nil if a grammar library for LANGUAGE is not available.  */)
+       TSLanguage *ts_language = lang.lang;
+       if (ts_language == NULL)
+ 	return Qnil;
+-      uint32_t version =  ts_language_version (ts_language);
++      uint32_t version =  treesit_language_abi_version (ts_language);
+       return make_fixnum((ptrdiff_t) version);
+     }
+ }

--- a/patches/tree-sitter-query-29.patch
+++ b/patches/tree-sitter-query-29.patch
@@ -1,0 +1,172 @@
+diff --git a/src/treesit.c b/src/treesit.c
+index 705ef6af39..7cc13136b9 100644
+--- a/src/treesit.c
++++ b/src/treesit.c
+@@ -411,17 +411,17 @@ static Lisp_Object Vtreesit_str_dot;
+ static Lisp_Object Vtreesit_str_question_mark;
+ static Lisp_Object Vtreesit_str_star;
+ static Lisp_Object Vtreesit_str_plus;
+-static Lisp_Object Vtreesit_str_pound_equal;
+-static Lisp_Object Vtreesit_str_pound_match;
+-static Lisp_Object Vtreesit_str_pound_pred;
++static Lisp_Object Vtreesit_str_pound_eq_question_mark;
++static Lisp_Object Vtreesit_str_pound_match_question_mark;
++static Lisp_Object Vtreesit_str_pound_pred_question_mark;
+ static Lisp_Object Vtreesit_str_open_bracket;
+ static Lisp_Object Vtreesit_str_close_bracket;
+ static Lisp_Object Vtreesit_str_open_paren;
+ static Lisp_Object Vtreesit_str_close_paren;
+ static Lisp_Object Vtreesit_str_space;
+-static Lisp_Object Vtreesit_str_equal;
+-static Lisp_Object Vtreesit_str_match;
+-static Lisp_Object Vtreesit_str_pred;
++static Lisp_Object Vtreesit_str_eq_question_mark;
++static Lisp_Object Vtreesit_str_match_question_mark;
++static Lisp_Object Vtreesit_str_pred_question_mark;
+ 
+ /* This is the limit on recursion levels for some tree-sitter
+    functions.  Remember to update docstrings when changing this
+@@ -2317,12 +2317,12 @@ See Info node `(elisp)Pattern Matching' for detailed explanation.  */)
+     return Vtreesit_str_star;
+   if (EQ (pattern, intern_c_string (":+")))
+     return Vtreesit_str_plus;
+-  if (EQ (pattern, QCequal))
+-    return Vtreesit_str_pound_equal;
+-  if (EQ (pattern, QCmatch))
+-    return Vtreesit_str_pound_match;
+-  if (EQ (pattern, QCpred))
+-    return Vtreesit_str_pound_pred;
++  if (BASE_EQ (pattern, QCequal) || BASE_EQ (pattern, QCeq_q))
++    return Vtreesit_str_pound_eq_question_mark;
++  if (BASE_EQ (pattern, QCmatch) || BASE_EQ (pattern, QCmatch_q))
++    return Vtreesit_str_pound_match_question_mark;
++  if (BASE_EQ (pattern, QCpred) || BASE_EQ (pattern, QCpred_q))
++    return Vtreesit_str_pound_pred_question_mark;
+   Lisp_Object opening_delimeter
+     = VECTORP (pattern)
+       ? Vtreesit_str_open_bracket : Vtreesit_str_open_paren;
+@@ -2350,7 +2350,9 @@ A PATTERN in QUERY can be
+     :*
+     :+
+     :equal
++    :eq?
+     :match
++    :match?
+     (TYPE PATTERN...)
+     [PATTERN...]
+     FIELD-NAME:
+@@ -2492,7 +2494,7 @@ treesit_predicate_equal (Lisp_Object args, struct capture_range captures)
+   return !NILP (Fstring_equal (text1, text2));
+ }
+ 
+-/* Handles predicate (#match "regexp" @node).  Return true if "regexp"
++/* Handles predicate (#match? "regexp" @node).  Return true if "regexp"
+    matches the text spanned by @node; return false otherwise.  Matching
+    is case-sensitive.  */
+ static bool
+@@ -2500,25 +2502,24 @@ treesit_predicate_match (Lisp_Object args, struct capture_range captures)
+ {
+   if (XFIXNUM (Flength (args)) != 2)
+     xsignal2 (Qtreesit_query_error,
+-	      build_string ("Predicate `match' requires two "
++	      build_string ("Predicate `match?' requires two "
+ 		            "arguments but only given"),
+ 	      Flength (args));
+ 
+-  Lisp_Object regexp = XCAR (args);
+-  Lisp_Object capture_name = XCAR (XCDR (args));
+-
+-  /* It's probably common to get the argument order backwards.  Catch
+-     this mistake early and show helpful explanation, because Emacs
+-     loves you.  (We put the regexp first because that's what
+-     string-match does.)  */
+-  if (!STRINGP (regexp))
+-    xsignal1 (Qtreesit_query_error,
+-	      build_string ("The first argument to `match' should "
+-		            "be a regexp string, not a capture name"));
+-  if (!SYMBOLP (capture_name))
+-    xsignal1 (Qtreesit_query_error,
+-	      build_string ("The second argument to `match' should "
+-		            "be a capture name, not a string"));
++  Lisp_Object arg1 = XCAR (args);
++  Lisp_Object arg2 = XCAR (XCDR (args));
++  Lisp_Object regexp = SYMBOLP (arg2) ? arg1 : arg2;
++  Lisp_Object capture_name = SYMBOLP (arg2) ? arg2 : arg1;
++
++  if (!STRINGP (regexp) || !SYMBOLP (capture_name))
++    {
++      xsignal2 (Qtreesit_query_error,
++		build_string ("Predicate `match?' takes a regexp "
++					  "and a node capture (order doesn't "
++					  "matter), but got"),
++		Flength (args));
++      return false;
++    }
+ 
+   Lisp_Object node = treesit_predicate_capture_name_to_node (capture_name,
+ 							     captures);
+@@ -2596,11 +2597,11 @@ treesit_eval_predicates (struct capture_range captures, Lisp_Object predicates)
+       Lisp_Object predicate = XCAR (tail);
+       Lisp_Object fn = XCAR (predicate);
+       Lisp_Object args = XCDR (predicate);
+-      if (!NILP (Fstring_equal (fn, Vtreesit_str_equal)))
++      if (!NILP (Fstring_equal (fn, Vtreesit_str_eq_question_mark)))
+ 	pass &= treesit_predicate_equal (args, captures);
+-      else if (!NILP (Fstring_equal (fn, Vtreesit_str_match)))
++      else if (!NILP (Fstring_equal (fn, Vtreesit_str_match_question_mark)))
+ 	pass &= treesit_predicate_match (args, captures);
+-      else if (!NILP (Fstring_equal (fn, Vtreesit_str_pred)))
++      else if (!NILP (Fstring_equal (fn, Vtreesit_str_pred_question_mark)))
+ 	pass &= treesit_predicate_pred (args, captures);
+       else
+ 	xsignal3 (Qtreesit_query_error,
+@@ -3517,8 +3518,11 @@ syms_of_treesit (void)
+ 
+   DEFSYM (QCanchor, ":anchor");
+   DEFSYM (QCequal, ":equal");
++  DEFSYM (QCeq_q, ":eq?");
+   DEFSYM (QCmatch, ":match");
++  DEFSYM (QCmatch_q, ":match?");
+   DEFSYM (QCpred, ":pred");
++  DEFSYM (QCpred_q, ":pred?");
+ 
+   DEFSYM (Qnot_found, "not-found");
+   DEFSYM (Qsymbol_error, "symbol-error");
+@@ -3611,12 +3615,12 @@ then in the system default locations for dynamic libraries, in that order.  */);
+   Vtreesit_str_star = build_pure_c_string ("*");
+   staticpro (&Vtreesit_str_plus);
+   Vtreesit_str_plus = build_pure_c_string ("+");
+-  staticpro (&Vtreesit_str_pound_equal);
+-  Vtreesit_str_pound_equal = build_pure_c_string ("#equal");
+-  staticpro (&Vtreesit_str_pound_match);
+-  Vtreesit_str_pound_match = build_pure_c_string ("#match");
+-  staticpro (&Vtreesit_str_pound_pred);
+-  Vtreesit_str_pound_pred = build_pure_c_string ("#pred");
++  staticpro (&Vtreesit_str_pound_eq_question_mark);
++  Vtreesit_str_pound_eq_question_mark = build_string ("#eq?");
++  staticpro (&Vtreesit_str_pound_match_question_mark);
++  Vtreesit_str_pound_match_question_mark = build_string ("#match?");
++  staticpro (&Vtreesit_str_pound_pred_question_mark);
++  Vtreesit_str_pound_pred_question_mark = build_string ("#pred?");
+   staticpro (&Vtreesit_str_open_bracket);
+   Vtreesit_str_open_bracket = build_pure_c_string ("[");
+   staticpro (&Vtreesit_str_close_bracket);
+@@ -3627,12 +3631,12 @@ then in the system default locations for dynamic libraries, in that order.  */);
+   Vtreesit_str_close_paren = build_pure_c_string (")");
+   staticpro (&Vtreesit_str_space);
+   Vtreesit_str_space = build_pure_c_string (" ");
+-  staticpro (&Vtreesit_str_equal);
+-  Vtreesit_str_equal = build_pure_c_string ("equal");
+-  staticpro (&Vtreesit_str_match);
+-  Vtreesit_str_match = build_pure_c_string ("match");
+-  staticpro (&Vtreesit_str_pred);
+-  Vtreesit_str_pred = build_pure_c_string ("pred");
++  staticpro (&Vtreesit_str_eq_question_mark);
++  Vtreesit_str_eq_question_mark = build_string ("eq?");
++  staticpro (&Vtreesit_str_match_question_mark);
++  Vtreesit_str_match_question_mark = build_string ("match?");
++  staticpro (&Vtreesit_str_pred_question_mark);
++  Vtreesit_str_pred_question_mark = build_string ("pred?");
+ 
+   defsubr (&Streesit_language_available_p);
+   defsubr (&Streesit_library_abi_version);

--- a/patches/tree-sitter-query-30.1.patch
+++ b/patches/tree-sitter-query-30.1.patch
@@ -1,0 +1,172 @@
+diff --git a/src/treesit.c b/src/treesit.c
+index f234698def..a8bc1a2c5e 100644
+--- a/src/treesit.c
++++ b/src/treesit.c
+@@ -415,17 +415,17 @@ static Lisp_Object Vtreesit_str_dot;
+ static Lisp_Object Vtreesit_str_question_mark;
+ static Lisp_Object Vtreesit_str_star;
+ static Lisp_Object Vtreesit_str_plus;
+-static Lisp_Object Vtreesit_str_pound_equal;
+-static Lisp_Object Vtreesit_str_pound_match;
+-static Lisp_Object Vtreesit_str_pound_pred;
++static Lisp_Object Vtreesit_str_pound_eq_question_mark;
++static Lisp_Object Vtreesit_str_pound_match_question_mark;
++static Lisp_Object Vtreesit_str_pound_pred_question_mark;
+ static Lisp_Object Vtreesit_str_open_bracket;
+ static Lisp_Object Vtreesit_str_close_bracket;
+ static Lisp_Object Vtreesit_str_open_paren;
+ static Lisp_Object Vtreesit_str_close_paren;
+ static Lisp_Object Vtreesit_str_space;
+-static Lisp_Object Vtreesit_str_equal;
+-static Lisp_Object Vtreesit_str_match;
+-static Lisp_Object Vtreesit_str_pred;
++static Lisp_Object Vtreesit_str_eq_question_mark;
++static Lisp_Object Vtreesit_str_match_question_mark;
++static Lisp_Object Vtreesit_str_pred_question_mark;
+ 
+ /* This is the limit on recursion levels for some tree-sitter
+    functions.  Remember to update docstrings when changing this value.
+@@ -2562,7 +2562,9 @@ PATTERN can be
+     :*
+     :+
+     :equal
++    :eq?
+     :match
++    :match?
+     (TYPE PATTERN...)
+     [PATTERN...]
+     FIELD-NAME:
+@@ -2582,12 +2584,12 @@ See Info node `(elisp)Pattern Matching' for detailed explanation.  */)
+     return Vtreesit_str_star;
+   if (BASE_EQ (pattern, QCplus))
+     return Vtreesit_str_plus;
+-  if (BASE_EQ (pattern, QCequal))
+-    return Vtreesit_str_pound_equal;
+-  if (BASE_EQ (pattern, QCmatch))
+-    return Vtreesit_str_pound_match;
+-  if (BASE_EQ (pattern, QCpred))
+-    return Vtreesit_str_pound_pred;
++  if (BASE_EQ (pattern, QCequal) || BASE_EQ (pattern, QCeq_q))
++    return Vtreesit_str_pound_eq_question_mark;
++  if (BASE_EQ (pattern, QCmatch) || BASE_EQ (pattern, QCmatch_q))
++    return Vtreesit_str_pound_match_question_mark;
++  if (BASE_EQ (pattern, QCpred) || BASE_EQ (pattern, QCpred_q))
++    return Vtreesit_str_pound_pred_question_mark;
+   Lisp_Object opening_delimeter
+     = VECTORP (pattern)
+       ? Vtreesit_str_open_bracket : Vtreesit_str_open_paren;
+@@ -2781,7 +2783,7 @@ treesit_predicate_equal (Lisp_Object args, struct capture_range captures,
+   return !NILP (Fstring_equal (text1, text2));
+ }
+ 
+-/* Handles predicate (#match "regexp" @node).  Return true if "regexp"
++/* Handles predicate (#match? "regexp" @node).  Return true if "regexp"
+    matches the text spanned by @node; return false otherwise.
+    Matching is case-sensitive.  If everything goes fine, don't touch
+    SIGNAL_DATA; if error occurs, set it to a suitable signal data.  */
+@@ -2791,26 +2793,24 @@ treesit_predicate_match (Lisp_Object args, struct capture_range captures,
+ {
+   if (list_length (args) != 2)
+     {
+-      *signal_data = list2 (build_string ("Predicate `match' requires two "
++      *signal_data = list2 (build_string ("Predicate `match?' requires two "
+ 					  "arguments but got"),
+ 			    Flength (args));
+       return false;
+     }
+-  Lisp_Object regexp = XCAR (args);
+-  Lisp_Object capture_name = XCAR (XCDR (args));
+-
+-  /* It's probably common to get the argument order backwards.  Catch
+-     this mistake early and show helpful explanation, because Emacs
+-     loves you.  (We put the regexp first because that's what
+-     string-match does.)  */
+-  if (!STRINGP (regexp))
+-    xsignal1 (Qtreesit_query_error,
+-	      build_string ("The first argument to `match' should "
+-		            "be a regexp string, not a capture name"));
+-  if (!SYMBOLP (capture_name))
+-    xsignal1 (Qtreesit_query_error,
+-	      build_string ("The second argument to `match' should "
+-		            "be a capture name, not a string"));
++  Lisp_Object arg1 = XCAR (args);
++  Lisp_Object arg2 = XCAR (XCDR (args));
++  Lisp_Object regexp = SYMBOLP (arg2) ? arg1 : arg2;
++  Lisp_Object capture_name = SYMBOLP (arg2) ? arg2 : arg1;
++
++  if (!STRINGP (regexp) || !SYMBOLP (capture_name))
++    {
++      *signal_data = list2 (build_string ("Predicate `match?' takes a regexp "
++	                                  "and a node capture (order doesn't "
++					  "matter), but got"),
++			    Flength (args));
++      return false;
++    }
+ 
+   Lisp_Object node = Qnil;
+   if (!treesit_predicate_capture_name_to_node (capture_name, captures, &node,
+@@ -2894,11 +2894,11 @@ treesit_eval_predicates (struct capture_range captures, Lisp_Object predicates,
+       Lisp_Object predicate = XCAR (tail);
+       Lisp_Object fn = XCAR (predicate);
+       Lisp_Object args = XCDR (predicate);
+-      if (!NILP (Fstring_equal (fn, Vtreesit_str_equal)))
++      if (!NILP (Fstring_equal (fn, Vtreesit_str_eq_question_mark)))
+ 	pass &= treesit_predicate_equal (args, captures, signal_data);
+-      else if (!NILP (Fstring_equal (fn, Vtreesit_str_match)))
++      else if (!NILP (Fstring_equal (fn, Vtreesit_str_match_question_mark)))
+ 	pass &= treesit_predicate_match (args, captures, signal_data);
+-      else if (!NILP (Fstring_equal (fn, Vtreesit_str_pred)))
++      else if (!NILP (Fstring_equal (fn, Vtreesit_str_pred_question_mark)))
+ 	pass &= treesit_predicate_pred (args, captures, signal_data);
+       else
+ 	{
+@@ -4162,8 +4162,11 @@ syms_of_treesit (void)
+   DEFSYM (QCstar, ":*");
+   DEFSYM (QCplus, ":+");
+   DEFSYM (QCequal, ":equal");
++  DEFSYM (QCeq_q, ":eq?");
+   DEFSYM (QCmatch, ":match");
++  DEFSYM (QCmatch_q, ":match?");
+   DEFSYM (QCpred, ":pred");
++  DEFSYM (QCpred_q, ":pred?");
+ 
+   DEFSYM (Qnot_found, "not-found");
+   DEFSYM (Qsymbol_error, "symbol-error");
+@@ -4294,12 +4297,12 @@ the symbol of that THING.  For example, (or sexp sentence).  */);
+   Vtreesit_str_star = build_pure_c_string ("*");
+   staticpro (&Vtreesit_str_plus);
+   Vtreesit_str_plus = build_pure_c_string ("+");
+-  staticpro (&Vtreesit_str_pound_equal);
+-  Vtreesit_str_pound_equal = build_pure_c_string ("#equal");
+-  staticpro (&Vtreesit_str_pound_match);
+-  Vtreesit_str_pound_match = build_pure_c_string ("#match");
+-  staticpro (&Vtreesit_str_pound_pred);
+-  Vtreesit_str_pound_pred = build_pure_c_string ("#pred");
++  staticpro (&Vtreesit_str_pound_eq_question_mark);
++  Vtreesit_str_pound_eq_question_mark = build_string ("#eq?");
++  staticpro (&Vtreesit_str_pound_match_question_mark);
++  Vtreesit_str_pound_match_question_mark = build_string ("#match?");
++  staticpro (&Vtreesit_str_pound_pred_question_mark);
++  Vtreesit_str_pound_pred_question_mark = build_string ("#pred?");
+   staticpro (&Vtreesit_str_open_bracket);
+   Vtreesit_str_open_bracket = build_pure_c_string ("[");
+   staticpro (&Vtreesit_str_close_bracket);
+@@ -4310,12 +4313,12 @@ the symbol of that THING.  For example, (or sexp sentence).  */);
+   Vtreesit_str_close_paren = build_pure_c_string (")");
+   staticpro (&Vtreesit_str_space);
+   Vtreesit_str_space = build_pure_c_string (" ");
+-  staticpro (&Vtreesit_str_equal);
+-  Vtreesit_str_equal = build_pure_c_string ("equal");
+-  staticpro (&Vtreesit_str_match);
+-  Vtreesit_str_match = build_pure_c_string ("match");
+-  staticpro (&Vtreesit_str_pred);
+-  Vtreesit_str_pred = build_pure_c_string ("pred");
++  staticpro (&Vtreesit_str_eq_question_mark);
++  Vtreesit_str_eq_question_mark = build_string ("eq?");
++  staticpro (&Vtreesit_str_match_question_mark);
++  Vtreesit_str_match_question_mark = build_string ("match?");
++  staticpro (&Vtreesit_str_pred_question_mark);
++  Vtreesit_str_pred_question_mark = build_string ("pred?");
+ 
+   defsubr (&Streesit_language_available_p);
+   defsubr (&Streesit_library_abi_version);

--- a/patches/tree-sitter-query-30.2.patch
+++ b/patches/tree-sitter-query-30.2.patch
@@ -1,0 +1,175 @@
+diff --git a/src/treesit.c b/src/treesit.c
+index f234698def..a8bc1a2c5e 100644
+--- a/src/treesit.c
++++ b/src/treesit.c
+@@ -415,18 +415,18 @@ static Lisp_Object Vtreesit_str_dot;
+ static Lisp_Object Vtreesit_str_question_mark;
+ static Lisp_Object Vtreesit_str_star;
+ static Lisp_Object Vtreesit_str_plus;
+-static Lisp_Object Vtreesit_str_pound_equal;
+-static Lisp_Object Vtreesit_str_pound_match;
+-static Lisp_Object Vtreesit_str_pound_pred;
++static Lisp_Object Vtreesit_str_pound_eq_question_mark;
++static Lisp_Object Vtreesit_str_pound_match_question_mark;
++static Lisp_Object Vtreesit_str_pound_pred_question_mark;
+ static Lisp_Object Vtreesit_str_open_bracket;
+ static Lisp_Object Vtreesit_str_close_bracket;
+ static Lisp_Object Vtreesit_str_open_paren;
+ static Lisp_Object Vtreesit_str_close_paren;
+ static Lisp_Object Vtreesit_str_space;
+-static Lisp_Object Vtreesit_str_equal;
+-static Lisp_Object Vtreesit_str_match;
+-static Lisp_Object Vtreesit_str_pred;
++static Lisp_Object Vtreesit_str_eq_question_mark;
++static Lisp_Object Vtreesit_str_match_question_mark;
++static Lisp_Object Vtreesit_str_pred_question_mark;
+ static Lisp_Object Vtreesit_str_empty;
+ 
+ /* This is the limit on recursion levels for some tree-sitter
+    functions.  Remember to update docstrings when changing this value.
+@@ -2562,7 +2562,9 @@ PATTERN can be
+     :*
+     :+
+     :equal
++    :eq?
+     :match
++    :match?
+     (TYPE PATTERN...)
+     [PATTERN...]
+     FIELD-NAME:
+@@ -2582,12 +2584,12 @@ See Info node `(elisp)Pattern Matching' for detailed explanation.  */)
+     return Vtreesit_str_star;
+   if (BASE_EQ (pattern, QCplus))
+     return Vtreesit_str_plus;
+-  if (BASE_EQ (pattern, QCequal))
+-    return Vtreesit_str_pound_equal;
+-  if (BASE_EQ (pattern, QCmatch))
+-    return Vtreesit_str_pound_match;
+-  if (BASE_EQ (pattern, QCpred))
+-    return Vtreesit_str_pound_pred;
++  if (BASE_EQ (pattern, QCequal) || BASE_EQ (pattern, QCeq_q))
++    return Vtreesit_str_pound_eq_question_mark;
++  if (BASE_EQ (pattern, QCmatch) || BASE_EQ (pattern, QCmatch_q))
++    return Vtreesit_str_pound_match_question_mark;
++  if (BASE_EQ (pattern, QCpred) || BASE_EQ (pattern, QCpred_q))
++    return Vtreesit_str_pound_pred_question_mark;
+   Lisp_Object opening_delimeter
+     = VECTORP (pattern)
+       ? Vtreesit_str_open_bracket : Vtreesit_str_open_paren;
+@@ -2781,7 +2783,7 @@ treesit_predicate_equal (Lisp_Object args, struct capture_range captures,
+   return !NILP (Fstring_equal (text1, text2));
+ }
+ 
+-/* Handles predicate (#match "regexp" @node).  Return true if "regexp"
++/* Handles predicate (#match? "regexp" @node).  Return true if "regexp"
+    matches the text spanned by @node; return false otherwise.
+    Matching is case-sensitive.  If everything goes fine, don't touch
+    SIGNAL_DATA; if error occurs, set it to a suitable signal data.  */
+@@ -2791,26 +2793,24 @@ treesit_predicate_match (Lisp_Object args, struct capture_range captures,
+ {
+   if (list_length (args) != 2)
+     {
+-      *signal_data = list2 (build_string ("Predicate `match' requires two "
++      *signal_data = list2 (build_string ("Predicate `match?' requires two "
+ 					  "arguments but got"),
+ 			    Flength (args));
+       return false;
+     }
+-  Lisp_Object regexp = XCAR (args);
+-  Lisp_Object capture_name = XCAR (XCDR (args));
+-
+-  /* It's probably common to get the argument order backwards.  Catch
+-     this mistake early and show helpful explanation, because Emacs
+-     loves you.  (We put the regexp first because that's what
+-     string-match does.)  */
+-  if (!STRINGP (regexp))
+-    xsignal1 (Qtreesit_query_error,
+-	      build_string ("The first argument to `match' should "
+-		            "be a regexp string, not a capture name"));
+-  if (!SYMBOLP (capture_name))
+-    xsignal1 (Qtreesit_query_error,
+-	      build_string ("The second argument to `match' should "
+-		            "be a capture name, not a string"));
++  Lisp_Object arg1 = XCAR (args);
++  Lisp_Object arg2 = XCAR (XCDR (args));
++  Lisp_Object regexp = SYMBOLP (arg2) ? arg1 : arg2;
++  Lisp_Object capture_name = SYMBOLP (arg2) ? arg2 : arg1;
++
++  if (!STRINGP (regexp) || !SYMBOLP (capture_name))
++    {
++      *signal_data = list2 (build_string ("Predicate `match?' takes a regexp "
++	                                  "and a node capture (order doesn't "
++					  "matter), but got"),
++			    Flength (args));
++      return false;
++    }
+ 
+   Lisp_Object node = Qnil;
+   if (!treesit_predicate_capture_name_to_node (capture_name, captures, &node,
+@@ -2894,11 +2894,11 @@ treesit_eval_predicates (struct capture_range captures, Lisp_Object predicates,
+       Lisp_Object predicate = XCAR (tail);
+       Lisp_Object fn = XCAR (predicate);
+       Lisp_Object args = XCDR (predicate);
+-      if (!NILP (Fstring_equal (fn, Vtreesit_str_equal)))
++      if (!NILP (Fstring_equal (fn, Vtreesit_str_eq_question_mark)))
+ 	pass &= treesit_predicate_equal (args, captures, signal_data);
+-      else if (!NILP (Fstring_equal (fn, Vtreesit_str_match)))
++      else if (!NILP (Fstring_equal (fn, Vtreesit_str_match_question_mark)))
+ 	pass &= treesit_predicate_match (args, captures, signal_data);
+-      else if (!NILP (Fstring_equal (fn, Vtreesit_str_pred)))
++      else if (!NILP (Fstring_equal (fn, Vtreesit_str_pred_question_mark)))
+ 	pass &= treesit_predicate_pred (args, captures, signal_data);
+       else
+ 	{
+@@ -4162,8 +4162,11 @@ syms_of_treesit (void)
+   DEFSYM (QCstar, ":*");
+   DEFSYM (QCplus, ":+");
+   DEFSYM (QCequal, ":equal");
++  DEFSYM (QCeq_q, ":eq?");
+   DEFSYM (QCmatch, ":match");
++  DEFSYM (QCmatch_q, ":match?");
+   DEFSYM (QCpred, ":pred");
++  DEFSYM (QCpred_q, ":pred?");
+ 
+   DEFSYM (Qnot_found, "not-found");
+   DEFSYM (Qsymbol_error, "symbol-error");
+@@ -4294,12 +4297,12 @@ the symbol of that THING.  For example, (or sexp sentence).  */);
+   Vtreesit_str_star = build_pure_c_string ("*");
+   staticpro (&Vtreesit_str_plus);
+   Vtreesit_str_plus = build_pure_c_string ("+");
+-  staticpro (&Vtreesit_str_pound_equal);
+-  Vtreesit_str_pound_equal = build_pure_c_string ("#equal");
+-  staticpro (&Vtreesit_str_pound_match);
+-  Vtreesit_str_pound_match = build_pure_c_string ("#match");
+-  staticpro (&Vtreesit_str_pound_pred);
+-  Vtreesit_str_pound_pred = build_pure_c_string ("#pred");
++  staticpro (&Vtreesit_str_pound_eq_question_mark);
++  Vtreesit_str_pound_eq_question_mark = build_string ("#eq?");
++  staticpro (&Vtreesit_str_pound_match_question_mark);
++  Vtreesit_str_pound_match_question_mark = build_string ("#match?");
++  staticpro (&Vtreesit_str_pound_pred_question_mark);
++  Vtreesit_str_pound_pred_question_mark = build_string ("#pred?");
+   staticpro (&Vtreesit_str_open_bracket);
+   Vtreesit_str_open_bracket = build_pure_c_string ("[");
+   staticpro (&Vtreesit_str_close_bracket);
+@@ -4310,14 +4313,14 @@ the symbol of that THING.  For example, (or sexp sentence).  */);
+   Vtreesit_str_close_paren = build_pure_c_string (")");
+   staticpro (&Vtreesit_str_space);
+   Vtreesit_str_space = build_pure_c_string (" ");
+-  staticpro (&Vtreesit_str_equal);
+-  Vtreesit_str_equal = build_pure_c_string ("equal");
+-  staticpro (&Vtreesit_str_match);
+-  Vtreesit_str_match = build_pure_c_string ("match");
+-  staticpro (&Vtreesit_str_pred);
+-  Vtreesit_str_pred = build_pure_c_string ("pred");
++  staticpro (&Vtreesit_str_eq_question_mark);
++  Vtreesit_str_eq_question_mark = build_string ("eq?");
++  staticpro (&Vtreesit_str_match_question_mark);
++  Vtreesit_str_match_question_mark = build_string ("match?");
++  staticpro (&Vtreesit_str_pred_question_mark);
++  Vtreesit_str_pred_question_mark = build_string ("pred?");
+   staticpro (&Vtreesit_str_empty);
+   Vtreesit_str_empty = build_pure_c_string ("");
+ 
+   defsubr (&Streesit_language_available_p);
+   defsubr (&Streesit_library_abi_version);


### PR DESCRIPTION
See https://github.com/purcell/nix-emacs-ci/issues/449. 

Changes:

- Generate a patch from https://github.com/emacs-mirror/emacs/commit/d587ce8c65a0e22ab0a63ef2873a3dfcfbeba166
- Adapt the patch to the older code base of Emacs which has not been applied the change of https://github.com/emacs-mirror/emacs/commit/38789e9a2878846cadb72fef58cc24872fe46ae4 yet.
- Apply the patch only to Emacs 29-30. emacs-snapshot (currently Emacs 31) already supports the latest tree-sitter.
- Apparently, not having the next commit on the file https://github.com/emacs-mirror/emacs/commit/b01435306a36e4e75671fbe7bacea351f89947d5 would cause runtime issues, so applied the patch as well.  Actually, I have added multiple variants of the patch due to slightly different patch contexts.