### PR TITLE
Specify which inputs to update with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     default-days: 7
 - package-ecosystem: nix
   directory: "/"
+  allow:
+    - dependency-name: "emacs-snapshot"
+    - dependency-name: "emacs-release-snapshot"
   schedule:
     interval: weekly
   commit-message:
@@ -20,5 +23,4 @@ updates:
   groups:
     emacs-snapshots:
       patterns:
-        - "emacs-snapshot"
-        - "emacs-release-snapshot"
+        - "emacs-*"


### PR DESCRIPTION
Update only emacs snapshot inputs with dependabot (follow-up to #453).