### PR TITLE
Update Emacs versions for master and release branches

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,7 @@
       flake = false;
     };
     emacs-release-snapshot = {
-      url = "github:emacs-mirror/emacs?ref=emacs-30";
+      url = "github:emacs-mirror/emacs?ref=emacs-31";
       flake = false;
     };
   };
@@ -164,8 +164,8 @@
                   emacs-29-4 = "29.4";
                   emacs-30-1 = "30.1";
                   emacs-30-2 = "30.2";
-                  emacs-release-snapshot = "30.2.50";
-                  emacs-snapshot = "31.0.50";
+                  emacs-release-snapshot = "31.0.50";
+                  emacs-snapshot = "32.0.50";
                 };
             in
             builtins.mapAttrs (


### PR DESCRIPTION
Now that the emacs-31 branch is cut, these versions have been bumped.